### PR TITLE
Remove dependency on x86_64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,3 @@ description = "Boot information that can be passed from a bootloader to an OS ke
 license = "MIT/Apache-2.0"
 name = "os_bootinfo"
 version = "0.2.0-alpha-011"
-
-[dependencies]
-x86_64 = "0.2.0-alpha"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,9 @@
 #![deny(improper_ctypes)]
 #![no_std]
 
-extern crate x86_64;
-
 pub use memory_map::*;
 
-use x86_64::structures::paging::PageTable;
-
-const VERSION: u64 = 3;
+const VERSION: u64 = 4;
 
 mod memory_map;
 
@@ -15,15 +11,15 @@ mod memory_map;
 #[repr(C)]
 pub struct BootInfo {
     pub version: u64,
-    pub p4_table: &'static mut PageTable,
+    pub p4_table_addr: u64,
     pub memory_map: MemoryMap,
 }
 
 impl BootInfo {
-    pub fn new(p4_table: &'static mut PageTable, memory_map: MemoryMap) -> Self {
+    pub fn new(p4_table_addr: u64, memory_map: MemoryMap) -> Self {
         BootInfo {
             version: VERSION,
-            p4_table,
+            p4_table_addr,
             memory_map
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,16 @@ impl BootInfo {
         BootInfo {
             version: VERSION,
             p4_table_addr,
-            memory_map
+            memory_map,
         }
     }
 
     pub fn check_version(&self) -> Result<(), ()> {
-        if self.version == VERSION { Ok(()) } else { Err(()) }
+        if self.version == VERSION {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -98,6 +98,17 @@ pub struct FrameRange {
 }
 
 impl FrameRange {
+    /// Create a new FrameRange from the passed start_addr and end_addr.
+    ///
+    /// The end_addr is exclusive.
+    pub fn new(start_addr: u64, end_addr: u64) -> Self {
+        let last_byte = end_addr - 1;
+        FrameRange {
+            start_frame_number: start_addr / PAGE_SIZE,
+            end_frame_number: (last_byte / PAGE_SIZE) + 1,
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.start_frame_number == self.end_frame_number
     }
@@ -174,14 +185,8 @@ impl From<E820MemoryRegion> for MemoryRegion {
             5 => MemoryRegionType::BadMemory,
             t => panic!("invalid region type {}", t),
         };
-        let start_frame_number = region.start_addr / PAGE_SIZE;
-        let last_byte = region.start_addr + region.len - 1;
-        let end_frame_number = (last_byte / PAGE_SIZE) + 1;
         MemoryRegion {
-            range: FrameRange {
-                start_frame_number,
-                end_frame_number,
-            },
+            range: FrameRange::new(region.start_addr, region.start_addr + region.len),
             region_type,
         }
     }

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -1,5 +1,5 @@
-use core::ops::{Deref, DerefMut};
 use core::fmt;
+use core::ops::{Deref, DerefMut};
 
 const PAGE_SIZE: u64 = 4096;
 
@@ -28,18 +28,18 @@ impl MemoryMap {
     pub fn sort(&mut self) {
         use core::cmp::Ordering;
 
-        self.entries.sort_unstable_by(|r1, r2|
+        self.entries.sort_unstable_by(|r1, r2| {
             if r1.range.is_empty() {
                 Ordering::Greater
             } else if r2.range.is_empty() {
                 Ordering::Less
             } else {
-                r1.range.start_frame_number.cmp(&r2.range.start_frame_number)
+                r1.range
+                    .start_frame_number
+                    .cmp(&r2.range.start_frame_number)
             }
-        );
-        if let Some(first_zero_index) = self.entries.iter()
-            .position(|r| r.range.is_empty())
-        {
+        });
+        if let Some(first_zero_index) = self.entries.iter().position(|r| r.range.is_empty()) {
             self.next_entry_index = first_zero_index as u64;
         }
     }
@@ -74,7 +74,7 @@ impl fmt::Debug for MemoryMap {
 #[repr(C)]
 pub struct MemoryRegion {
     pub range: FrameRange,
-    pub region_type: MemoryRegionType
+    pub region_type: MemoryRegionType,
 }
 
 impl MemoryRegion {

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -101,13 +101,24 @@ impl FrameRange {
     pub fn is_empty(&self) -> bool {
         self.start_frame_number == self.end_frame_number
     }
+
+    pub fn start_addr(&self) -> u64 {
+        self.start_frame_number * PAGE_SIZE
+    }
+
+    pub fn end_addr(&self) -> u64 {
+        self.end_frame_number * PAGE_SIZE
+    }
 }
 
 impl fmt::Debug for FrameRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let start_addr = self.start_frame_number * PAGE_SIZE;
-        let end_addr = self.end_frame_number * PAGE_SIZE;
-        write!(f, "FrameRange({:#x}..{:#x})", start_addr, end_addr)
+        write!(
+            f,
+            "FrameRange({:#x}..{:#x})",
+            self.start_addr(),
+            self.end_addr()
+        )
     }
 }
 


### PR DESCRIPTION
With the dependency, every x86_64 update would be a breaking change and require updating the `VERSION` constant. This is not feasable, therefore this PR removes the dependency.

This makes the usage a bit less ergonomic for now, but we plan to add conversion methods to other crates (e.g. frame range conversion methods to x86_64).

cc @lachlansneff 